### PR TITLE
Run tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+    - "2.6"
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+install:
+    - "python setup.py develop"
+    - "pip install pytest"
+script: py.test


### PR DESCRIPTION
With this configuration it is possible to enable running tests on each push on [Travis CI](https://travis-ci.org/).

Please note that currently the tests fail on Python 3.6 (see logs on https://travis-ci.org/lubomir/beanbag/builds/188245649)