### PR TITLE
Fix python 3.6 metaclass compatibility

### DIFF
--- a/beanbag/namespace.py
+++ b/beanbag/namespace.py
@@ -108,6 +108,8 @@ class NamespaceMeta(type):
             qn = nmspc["__qualname__"]
             nmspc["__qualname__"] = qn + "Base"
 
+            classcell = nmspc.pop('__classcell__', None)
+
         basecls = type.__new__(type, name + "Base", basebases, nmspc)
 
         conv_nmspc = mcls.make_namespace(basecls)
@@ -116,6 +118,8 @@ class NamespaceMeta(type):
             conv_nmspc["__module__"] = nmspc["__module__"]
         if qn is not None:
             conv_nmspc["__qualname__"] = qn
+        if classcell is  not None
+            conv_nmspc['__classcell__'] = classcell
 
         cls = type.__new__(mcls, name, bases, conv_nmspc)
         basecls.Namespace = cls

--- a/beanbag/namespace.py
+++ b/beanbag/namespace.py
@@ -104,11 +104,12 @@ class NamespaceMeta(type):
             basebases = (NamespaceBase,)
 
         qn = None
+
+        classcell = nmspc.pop('__classcell__', None)
+
         if "__qualname__" in nmspc:
             qn = nmspc["__qualname__"]
             nmspc["__qualname__"] = qn + "Base"
-
-            classcell = nmspc.pop('__classcell__', None)
 
         basecls = type.__new__(type, name + "Base", basebases, nmspc)
 
@@ -118,7 +119,7 @@ class NamespaceMeta(type):
             conv_nmspc["__module__"] = nmspc["__module__"]
         if qn is not None:
             conv_nmspc["__qualname__"] = qn
-        if classcell is  not None
+        if classcell is not None:
             conv_nmspc['__classcell__'] = classcell
 
         cls = type.__new__(mcls, name, bases, conv_nmspc)


### PR DESCRIPTION
Currently the test_sane_inheritance fail for Python 3.6

This is due to the changes done at: http://bugs.python.org/issue23722

Also some more details can be found here: https://docs.python.org/3/reference/datamodel.html#creating-the-class-object

This pull request addresses this issue for Python 3.6.

